### PR TITLE
Not all negative Celsius measurements convert to a negative Fahrenheit

### DIFF
--- a/aosong/am2315.py
+++ b/aosong/am2315.py
@@ -133,6 +133,10 @@ class Sensor:
         temp_H &=0x7F
 
         tempC = (temp_H*256+temp_L)/10
+
+        if negative:
+            tempC = -abs(tempC)
+
         tempF = self.c_to_f(tempC)
 
         # Verify CRC here
@@ -145,10 +149,6 @@ class Sensor:
             assert(0)
             self.lastError('CRC error in sensor data.')
             return None
-
-        if negative:
-            tempC = -abs(tempC)
-            tempF = -abs(tempF)
 
         return (humidity, tempC, tempF)
 


### PR DESCRIPTION
In your code, all Celsius measurements will be converted to Fahrenheit, then if negative is True, both Celsius and Fahrenheit will be set negative at the same time. However, because of the difference in scales, there are a range of measurements that are both negative in Celsius and positive in Fahrenheit.

For example, -5C = 23F

Therefore, if Celsius is negative, it should be set negative, when go through the c_to_f() conversion to Fahrenheit.
